### PR TITLE
fix: 更新聊天服务导入路径

### DIFF
--- a/server/routers/canvas.py
+++ b/server/routers/canvas.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Request, Depends
 #from routers.agent import chat
-from services.chat_service import handle_chat
+from services.new_chat import handle_chat
 from services.db_service import db_service
 from utils.auth_utils import get_current_user_optional, get_user_uuid_for_database_operations, CurrentUser
 from typing import Optional


### PR DESCRIPTION
- 将 `canvas.py` 中的聊天服务导入路径从 `services.chat_service` 修改为 `services.new_chat`，确保使用最新的聊天服务实现。