### PR TITLE
feat: 更新聊天功能以支持模型名称配置

### DIFF
--- a/react/src/api/canvas.ts
+++ b/react/src/api/canvas.ts
@@ -23,8 +23,9 @@ export async function createCanvas(data: {
     provider: string
     model: string
     url: string
-  }
+  } | null
   tool_list: ToolInfo[]
+  model_name?: string
   system_prompt: string
   template_id?: number
 }): Promise<{ id: string }> {

--- a/react/src/components/chat/Chat.tsx
+++ b/react/src/components/chat/Chat.tsx
@@ -790,7 +790,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
   }
 
   const onSendMessages = useCallback(
-    (data: Message[], modelName: string) => {
+    (data: Message[], configs: {
+      textModel: ModelInfo | null
+      toolList: ToolInfo[]
+      modelName: string
+    }) => {
       const startTime = performance.now()
       setPending('text')
       setMessages(data)
@@ -803,7 +807,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
         sessionId: effectiveSessionId,
         canvasId: canvasId,
         newMessages: data,
-        modelName: modelName,
+        modelName: configs.modelName,
         systemPrompt: localStorage.getItem('system_prompt') || DEFAULT_SYSTEM_PROMPT,
       })
       if (searchSessionId !== effectiveSessionId) {

--- a/react/src/components/chat/ChatTextarea.tsx
+++ b/react/src/components/chat/ChatTextarea.tsx
@@ -42,7 +42,11 @@ type ChatTextareaProps = {
   className?: string
   messages: Message[]
   sessionId?: string
-  onSendMessages: (data: Message[], modelName: string) => void
+  onSendMessages: (data: Message[], configs: {
+    textModel: ModelInfo | null
+    toolList: ToolInfo[]
+    modelName: string
+  }) => void
   onCancelChat?: () => void
 }
 
@@ -258,7 +262,11 @@ const ChatTextarea: React.FC<ChatTextareaProps> = ({
         localStorage.setItem('current_selected_model', modelName)
       }
     }
-    onSendMessages(newMessage, modelName)
+    onSendMessages(newMessage, {
+      textModel: textModel ? { ...textModel, type: 'text' as const } : null,
+      toolList: selectedTools || [],
+      modelName
+    })
   }, [
     pending,
     textModel,

--- a/react/src/routes/index.tsx
+++ b/react/src/routes/index.tsx
@@ -94,6 +94,7 @@ function Home() {
                   session_id: nanoid(),
                   text_model: configs.textModel,
                   tool_list: configs.toolList,
+                  model_name: configs.modelName,
                   system_prompt: localStorage.getItem('system_prompt') || DEFAULT_SYSTEM_PROMPT,
                 })
               }}

--- a/react/src/routes/template-use.$templateId.tsx
+++ b/react/src/routes/template-use.$templateId.tsx
@@ -201,6 +201,20 @@ function TemplateUsePage() {
 
       // 1. 先创建画布
       setGeneratingStep('正在创建画布...')
+      // 获取当前选择的模型名称
+      const currentSelectedModel = localStorage.getItem('current_selected_model')
+      let modelName = ''
+      
+      if (currentSelectedModel) {
+        modelName = currentSelectedModel
+      } else if (textModel) {
+        modelName = textModel.model
+        localStorage.setItem('current_selected_model', modelName)
+      } else {
+        modelName = 'gpt-4o-mini' // 默认模型
+        localStorage.setItem('current_selected_model', modelName)
+      }
+
       const canvasResult = await createCanvas({
         name: `${template?.title} - ${characterName}`,
         canvas_id: canvasId,
@@ -217,6 +231,7 @@ function TemplateUsePage() {
           url: '',
         },
         tool_list: selectedTools && selectedTools.length > 0 ? selectedTools : [],
+        model_name: modelName,
         system_prompt: systemPrompt,
         template_id: parseInt(templateId),
       })

--- a/server/services/new_chat/chat_service.py
+++ b/server/services/new_chat/chat_service.py
@@ -117,15 +117,41 @@ async def handle_chat(data: Dict[str, Any]) -> None:
     template_id: str = data.get('template_id', '')
     user_info: Dict[str, Any] = data.get('user_info', {})
     model_name: str = data.get('model_name', '')
+    text_model_data = data.get('text_model')
     
     # 添加详细的调试信息
     logger.info(f"🔍 [DEBUG] 前端传入的完整请求数据 keys: {list(data.keys())}")
     logger.info(f"🔍 [DEBUG] 前端传入的 model_name: '{model_name}'")
+    logger.info(f"🔍 [DEBUG] 前端传入的 text_model: {text_model_data}")
     
-    # 如果没有传递模型名称，使用默认值
+    # 类型安全检查：确保 model_name 是字符串
+    if isinstance(model_name, dict):
+        logger.warning(f"🚨 [WARNING] model_name 是字典类型，尝试提取 modelName 字段: {model_name}")
+        if 'modelName' in model_name:
+            model_name = model_name['modelName']
+            logger.info(f"🔧 [DEBUG] 从字典中提取模型名称: {model_name}")
+        else:
+            model_name = ''
+            logger.warning(f"🚨 [WARNING] 字典中没有 modelName 字段，重置为空字符串")
+    
+    # 如果没有传递模型名称，尝试从 text_model 中提取
     if not model_name:
-        model_name = 'gpt-4o'
-        logger.info(f"🔍 [DEBUG] 使用默认模型: {model_name}")
+        if text_model_data and isinstance(text_model_data, dict):
+            model_name = text_model_data.get('model', '')
+            logger.info(f"🔍 [DEBUG] 从 text_model 中提取模型名称: {model_name}")
+        
+        # 如果还是没有，使用默认值
+        if not model_name:
+            model_name = 'gpt-4o'
+            logger.info(f"🔍 [DEBUG] 使用默认模型: {model_name}")
+        else:
+            logger.info(f"🔍 [DEBUG] 成功提取模型名称: {model_name}")
+    
+    # 最终验证：确保 model_name 是字符串类型
+    if not isinstance(model_name, str):
+        logger.error(f"🚨 [ERROR] model_name 类型错误，期望字符串，实际收到: {type(model_name)}, 值: {model_name}")
+        model_name = 'gpt-4o'  # 强制使用默认值
+        logger.info(f"🔧 [DEBUG] 强制使用默认模型: {model_name}")
     
     # 根据模型名称确定提供商
     provider = ''


### PR DESCRIPTION
- 在 `canvas.ts` 中将 `model_name` 属性设为可选，并允许传入 `null`。
- 修改 `Chat.tsx` 和 `ChatTextarea.tsx` 中的 `onSendMessages` 方法，更新参数结构以包含 `textModel` 和 `toolList`。
- 在 `index.tsx` 和 `template-use.$templateId.tsx` 中添加对 `model_name` 的支持，确保在创建画布时使用正确的模型名称。
- 在 `chat_service.py` 中增强模型名称的提取逻辑，确保从请求数据中安全地获取模型名称并提供默认值。