### PR TITLE
feat: 更新 Google 提供者配置，新增文本模型支持

### DIFF
--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -49,6 +49,7 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
     'google': {
         'models': {
             'gemini-2.5-flash-image': {'type': 'image'},
+            'gemini-2.5-pro': {'type': 'text'},
         },
         'url': 'https://api.tu-zi.com/v1',
         'api_key': 'sk-CRJTvndo8xN0nmzTe5fyij77T0tmT7ZMcjLZwMzZ0RmvkOP0',


### PR DESCRIPTION
- 在 `config_service.py` 中为 Google 提供者新增 `gemini-2.5-pro` 文本模型配置，扩展模型类型支持。