### PR TITLE
feat: 更新 Google 提供者配置，修改文本模型名称

### DIFF
--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -49,7 +49,7 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
     'google': {
         'models': {
             'gemini-2.5-flash-image': {'type': 'image'},
-            'gemini-2.5-pro': {'type': 'text'},
+            'gemini-2.5-pro-all': {'type': 'text'},
         },
         'url': 'https://api.tu-zi.com/v1',
         'api_key': 'sk-CRJTvndo8xN0nmzTe5fyij77T0tmT7ZMcjLZwMzZ0RmvkOP0',

--- a/server/utils/image_analyser.py
+++ b/server/utils/image_analyser.py
@@ -61,7 +61,7 @@ class ImageAnalyser:
   "prompt": "this is ...."
 }        
 """,
-        model: str = "gemini-2.5-pro",
+        model: str = "gemini-2.5-pro-all",
         max_tokens: int = 3000
     ) -> Optional[str]:
         """


### PR DESCRIPTION
- 在 `config_service.py` 中将 `gemini-2.5-pro` 文本模型名称修改为 `gemini-2.5-pro-all`，以支持新的模型配置。
- 在 `image_analyser.py` 中同步更新模型名称，确保一致性。