### PR TITLE
🚨 fix(PricingPage): 临时隐藏支付按钮

### DIFF
--- a/react/src/routes/pricing.tsx
+++ b/react/src/routes/pricing.tsx
@@ -623,7 +623,8 @@ function PricingPage() {
                   </CardContent>
 
                   <CardFooter className='pt-4'>
-                    {/* 🎯 显示所有按钮 - 支付功能已恢复 */}
+                    {/* 🚨 临时隐藏支付按钮 - 支付功能暂未开通 */}
+                    {false && (
                     <Button
                       variant={buttonVariant}
                       className='w-full'
@@ -668,6 +669,7 @@ function PricingPage() {
                         }
                       })()}
                     </Button>
+                    )}
                   </CardFooter>
                 </Card>
               )


### PR DESCRIPTION
- 在PricingPage中将支付按钮临时隐藏，因支付功能尚未开通，确保用户体验不受影响。
- 更新注释以反映当前状态，避免用户误解。