### PR TITLE
✨ feat(.gitignore): 更新忽略文件列表，新增.VSCodeCounter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ user_data/
 .continue
 
 .env
+.VSCodeCounter


### PR DESCRIPTION
- 在.gitignore中添加了.VSCodeCounter，以避免版本控制中包含VSCode计数器生成的文件。
- 确保.env文件被忽略，保持环境配置的安全性。