### PR TITLE
✨ feat(ChatService): 更新意图识别逻辑和调试日志

### DIFF
--- a/server/services/new_chat/chat_service.py
+++ b/server/services/new_chat/chat_service.py
@@ -915,16 +915,16 @@ async def _check_video_or_image(messages: List[Dict[str, Any]]) -> str:
 返回:"""
         
         response = await intent_client.chat.completions.create(
-                         model="gpt-5-2025-08-07",
+                         model="gpt-5-all",
                          messages=[{"role": "user", "content": prompt}],
                          max_tokens=100,
                          temperature=0.1)
 
         result = response.choices[0].message.content.strip().lower()
-        logger.info(f"🔍 [DEBUG] 意图识别结果: {result}")
+        logger.info(f"🔍 [DEBUG] 带图片上传，意图识别结果: {result}")
         # 确保返回有效的意图
-        if result not in ['video', 'image', 'text']:
-            return 'text'  # 默认返回文本意图
+        if result not in ['video', 'image']:
+            return 'image'  # 默认返回文本意图
         return result
     else:
         # 通过文本内容判断是视频还是图片
@@ -957,7 +957,7 @@ async def _check_video_or_image(messages: List[Dict[str, Any]]) -> str:
                          temperature=0.1)
 
         result = response.choices[0].message.content.strip().lower()
-        logger.info(f"🔍 [DEBUG] 意图识别结果: {result}")
+        logger.info(f"🔍 [DEBUG] 不带图片上传，意图识别结果: {result}")
         # 确保返回有效的意图
         if result not in ['video', 'image', 'text']:
             return 'text'  # 默认返回文本意图

--- a/server/services/new_chat/tuzi_llm_service.py
+++ b/server/services/new_chat/tuzi_llm_service.py
@@ -337,7 +337,6 @@ class TuziLLMService:
                 # 步骤3: 不是画图，直接走用户设定的大模型调用
                 return await self._handle_text_conversation(model_name, user_prompt, user_info, stream=stream)
             elif user_has_drawing_intent == "image":
-                logger.info("💬 检测到画图意图，执行图片生成流程")
                 ##image_model = self._get_image_generation_model(model_name)
                 if len(image_content) > 0:
                     logger.info("🖼️ 检测到图片上传，执行图片编辑流程")


### PR DESCRIPTION
- 修改_check_video_or_image函数，更新模型为“gpt-5-all”以增强意图识别能力。
- 调整调试日志，明确区分带图片和不带图片的意图识别结果。
- 修改默认返回值逻辑，确保在未识别到有效意图时返回'image'，提升识别准确性。