### PR TITLE
🔧 新增与优化：集成qwen图像编辑功能

### DIFF
--- a/react/src/constants.ts
+++ b/react/src/constants.ts
@@ -56,6 +56,10 @@ export const PROVIDER_NAME_MAPPING: {
     name: 'Doubao',
     icon: `${BASE_API_URL}/static/llm_icon/doubao.png`,
   },
+  qwen: {
+    name: 'qwen',
+    icon: `${BASE_API_URL}/static/llm_icon/qwen.svg`,
+  },
 }
 
 // Tool call name mapping

--- a/server/routers/root_router.py
+++ b/server/routers/root_router.py
@@ -110,9 +110,11 @@ async def list_tools(request: Request, current_user: Optional[CurrentUser] = Dep
         if tool_info.get('provider') == 'system':
             continue
         provider = tool_info['provider']
+        logger.info(f"tool_info: {tool_info}")
         provider_api_key = config[provider].get('api_key', '').strip()
         if provider != 'comfyui' and not provider_api_key:
             continue
+        
         res.append({
             'id': tool_id,
             'provider': tool_info.get('provider', ''),

--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -62,6 +62,13 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
         'url': 'https://api.apiplus.org/v1',
         'api_key': 'sk-T5GzBCTpRm92Po9G9WU9B19w1p1pxHJ8qwfcAcZ47MdZCzEM',
     },
+    'qwen': {
+        'models': {
+            'qwen-image-edit-plus': {'type': 'image'}
+        },
+        'url': 'https://api.apiplus.org/v1',
+        'api_key': 'sk-T5GzBCTpRm92Po9G9WU9B19w1p1pxHJ8qwfcAcZ47MdZCzEM',
+    },
     'yunwu': {
         'models': {},
         'url': 'https://api.apiplus.org/v1',

--- a/server/services/new_chat/tuzi_llm_service.py
+++ b/server/services/new_chat/tuzi_llm_service.py
@@ -804,7 +804,8 @@ class TuziLLMService:
     async def gemini_edit_image_by_yunwu(
         self,
         file_path: list[str],
-        prompt: str
+        prompt: str,
+        model_name: str = "nano-banana"
     ) -> Optional[Dict[str, str]]:
         """
         使用云雾AI编辑图片 - 异步任务模式
@@ -826,18 +827,32 @@ class TuziLLMService:
         logger.info(f"🎯 [DEBUG] 接收到的参数: prompt='{prompt[:100]}...'")
 
         try:
-            # 步骤2: 提交编辑任务
-            edit_url = "https://yunwu.ai/fal-ai/nano-banana/edit"
             headers = {
                 'Authorization': f'Bearer sk-T5GzBCTpRm92Po9G9WU9B19w1p1pxHJ8qwfcAcZ47MdZCzEM',
                 'content-type': 'application/json'
             }
-            
-            request_data = {
-                "prompt": prompt,
-                "image_urls": file_path,
-                "num_images": 1
-            }
+
+            # 步骤2: 提交编辑任务
+            if model_name == "nano-banana":
+                edit_url = f"https://yunwu.ai/fal-ai/{model_name}/edit"
+                request_data = {
+                    "prompt": prompt,
+                    "image_urls": file_path,
+                    "num_images": 1
+                }
+            elif model_name == "qwen-image-edit-plus":
+                edit_url = f"https://yunwu.ai/fal-ai/{model_name}"
+                request_data = {
+                    "prompt": prompt,
+                    "image_size": "square_hd",
+                    "num_inference_steps": 50,
+                    "guidance_scale": 4,
+                    "num_images": 1,
+                    "enable_safety_checker": True,
+                    "output_format": "png",
+                    "image_urls": file_path,
+                    "negative_prompt": "blurry, ugly"
+                }
             
             logger.info(f"🚀 [DEBUG] 提交编辑任务到: {edit_url}")
             # logger.info(f"📝 [DEBUG] 请求数据: {request_data}")
@@ -863,7 +878,7 @@ class TuziLLMService:
                         return None
                     
                     # 步骤3: 轮询查询任务状态
-                    query_url = f"https://yunwu.ai/fal-ai/nano-banana/requests/{request_id}"
+                    query_url = f"https://yunwu.ai/fal-ai/{model_name}/requests/{request_id}"
                     max_attempts = 60  # 最多查询60次
                     attempt = 0
                     

--- a/server/services/tool_service.py
+++ b/server/services/tool_service.py
@@ -50,6 +50,7 @@ from tools.generate_image_by_recraft_v3_replicate import (
 )
 from tools.generate_video_by_hailuo_02_jaaz import generate_video_by_hailuo_02_jaaz
 from tools.generate_video_by_veo3_fast_yunwu import generate_video_by_veo3_fast_yunwu
+from tools.generate_image_by_qwen_image_edit_plus import generate_image_by_qwen_image_edit_plus
 from tools.generate_image_by_midjourney_jaaz import generate_image_by_midjourney_jaaz
 from tools.generate_image_by_goolgle_nano_banana import generate_image_by_google_nano_banana
 from tools.generate_image_by_doubao_seedream_4 import generate_image_by_doubao_seedream_4_0
@@ -62,6 +63,12 @@ TOOL_MAPPING: Dict[str, ToolInfo] = {
         "type": "image",
         "provider": "google",
         "tool_function": generate_image_by_google_nano_banana,
+    },
+    "generate_image_by_qwen_image_edit_plus": {
+        "display_name": "qwen-image-edit-plus",
+        "type": "image",
+        "provider": "qwen",
+        "tool_function": generate_image_by_qwen_image_edit_plus,
     },
      "generate_image_by_doubao_seedream_4_0": {
         "display_name": "seedream-4.0",

--- a/server/static/llm_icon/qwen.svg
+++ b/server/static/llm_icon/qwen.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1000 1000" style="enable-background:new 0 0 1000 1000;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:url(#路径_00000142149374390968596540000011861634901242821287_);}
+	.st2{fill:url(#路径_00000100351054190099802430000015496761342839896254_);}
+	.st3{fill:url(#路径_00000119116943289704177040000003514825658580232070_);}
+	.st4{fill:url(#形状_00000078036495883892160520000012562460980012541574_);}
+	.st5{fill:url(#形状_00000049191005591686130650000012081508577745099186_);}
+	.st6{fill:url(#形状_00000021838912894269284010000017160231820371357860_);}
+</style>
+<g id="通义法睿logo_00000062873522637356860670000004236275241195608251_" transform="translate(2, 2)">
+	<g id="编组_00000059292297503122986130000012981252646097043102_" transform="translate(2, 1)">
+		<polygon id="路径_00000169523983134138038260000012693425703445569688_" class="st0" points="404.5,167.6 456,255.9 
+			404.5,343.2 816.2,343.2 764.7,417.5 363.4,417.5 306.8,335.3 		"/>
+		<polygon id="路径_00000028292663779449605350000010827990842055538601_" class="st0" points="204.1,343.2 300.6,343.2 
+			503.3,691.1 446.1,789.2 250.2,789.2 301.7,677.7 399.1,677.7 		"/>
+		<polygon id="路径_00000070099265625814547910000015844384453726213052_" class="st0" points="456,785.4 507.4,873.8 
+			713.2,520.7 764.7,603.4 867.7,603.4 769.9,417.5 656.7,417.5 		"/>
+	</g>
+	<g id="编组_00000019666295283373839220000010825971624781403560_" transform="translate(2, 1)">
+		
+			<linearGradient id="路径_00000111190569101487421850000004056919694061981851_" gradientUnits="userSpaceOnUse" x1="8.4543" y1="1093.8264" x2="34.7923" y2="1122.2434" gradientTransform="matrix(13.7081 0 0 -7.1237 251.7404 8206.3564)">
+			<stop  offset="0" style="stop-color:#615CED;stop-opacity:0.5"/>
+			<stop  offset="0" style="stop-color:#6964ED;stop-opacity:0.53"/>
+			<stop  offset="1.000000e-02" style="stop-color:#8884F1;stop-opacity:0.62"/>
+			<stop  offset="3.000000e-02" style="stop-color:#A4A2F4;stop-opacity:0.72"/>
+			<stop  offset="4.000000e-02" style="stop-color:#BDBBF7;stop-opacity:0.79"/>
+			<stop  offset="6.000000e-02" style="stop-color:#D2D0F9;stop-opacity:0.86"/>
+			<stop  offset="7.000000e-02" style="stop-color:#E2E1FB;stop-opacity:0.91"/>
+			<stop  offset="9.000000e-02" style="stop-color:#EFEFFD;stop-opacity:0.95"/>
+			<stop  offset="0.12" style="stop-color:#F8F8FE;stop-opacity:0.98"/>
+			<stop  offset="0.15" style="stop-color:#FDFDFE"/>
+			<stop  offset="0.25" style="stop-color:#FFFFFF"/>
+		</linearGradient>
+		
+			<polygon id="路径_00000147915398988286224150000013703939952839049903_" style="fill:url(#路径_00000111190569101487421850000004056919694061981851_);" points="
+			404.5,167.6 456,255.9 404.5,343.2 816.2,343.2 764.7,417.5 363.4,417.5 306.8,335.3 		"/>
+		
+			<linearGradient id="路径_00000133515112155870458500000015251568328909032584_" gradientUnits="userSpaceOnUse" x1="33.9366" y1="1031.8864" x2="-12.858" y2="1049.9409" gradientTransform="matrix(8.1694 0 0 -11.8763 226.6775 12949.3926)">
+			<stop  offset="0" style="stop-color:#615CED;stop-opacity:0.5"/>
+			<stop  offset="0" style="stop-color:#6964ED;stop-opacity:0.53"/>
+			<stop  offset="1.000000e-02" style="stop-color:#8884F1;stop-opacity:0.62"/>
+			<stop  offset="3.000000e-02" style="stop-color:#A4A2F4;stop-opacity:0.72"/>
+			<stop  offset="4.000000e-02" style="stop-color:#BDBBF7;stop-opacity:0.79"/>
+			<stop  offset="6.000000e-02" style="stop-color:#D2D0F9;stop-opacity:0.86"/>
+			<stop  offset="7.000000e-02" style="stop-color:#E2E1FB;stop-opacity:0.91"/>
+			<stop  offset="9.000000e-02" style="stop-color:#EFEFFD;stop-opacity:0.95"/>
+			<stop  offset="0.12" style="stop-color:#F8F8FE;stop-opacity:0.98"/>
+			<stop  offset="0.15" style="stop-color:#FDFDFE"/>
+			<stop  offset="0.25" style="stop-color:#FFFFFF"/>
+		</linearGradient>
+		
+			<polygon id="路径_00000139985045638711752690000007227136393069410184_" style="fill:url(#路径_00000133515112155870458500000015251568328909032584_);" points="
+			250.1,789.2 301.7,677.7 399.1,677.8 204.1,343.2 300.5,343.2 503.3,691.1 446.1,789.2 		"/>
+		
+			<linearGradient id="路径_00000095308829845534756670000002115062820100360377_" gradientUnits="userSpaceOnUse" x1="37.608" y1="1056.6146" x2="37.6047" y2="1017.4094" gradientTransform="matrix(11.0774 0 0 -11.6388 245.2323 12715.2598)">
+			<stop  offset="0" style="stop-color:#615CED;stop-opacity:0.5"/>
+			<stop  offset="0" style="stop-color:#6964ED;stop-opacity:0.53"/>
+			<stop  offset="1.000000e-02" style="stop-color:#8884F1;stop-opacity:0.62"/>
+			<stop  offset="3.000000e-02" style="stop-color:#A4A2F4;stop-opacity:0.72"/>
+			<stop  offset="4.000000e-02" style="stop-color:#BDBBF7;stop-opacity:0.79"/>
+			<stop  offset="6.000000e-02" style="stop-color:#D2D0F9;stop-opacity:0.86"/>
+			<stop  offset="7.000000e-02" style="stop-color:#E2E1FB;stop-opacity:0.91"/>
+			<stop  offset="9.000000e-02" style="stop-color:#EFEFFD;stop-opacity:0.95"/>
+			<stop  offset="0.12" style="stop-color:#F8F8FE;stop-opacity:0.98"/>
+			<stop  offset="0.15" style="stop-color:#FDFDFE"/>
+			<stop  offset="0.25" style="stop-color:#FFFFFF"/>
+		</linearGradient>
+		
+			<polygon id="路径_00000016051347413104335230000011739271525438745479_" style="fill:url(#路径_00000095308829845534756670000002115062820100360377_);" points="
+			867.7,603.4 764.7,603.4 713.2,520.7 507.4,873.8 456,785.6 656.7,417.5 769.9,417.5 		"/>
+	</g>
+	
+		<linearGradient id="形状_00000075134058584377680020000000290633275844112275_" gradientUnits="userSpaceOnUse" x1="29.4221" y1="1038.2013" x2="-3.0221" y2="1018.9127" gradientTransform="matrix(20 0 0 -20 234 21064)">
+		<stop  offset="0" style="stop-color:#615CED"/>
+		<stop  offset="0.17" style="stop-color:#6156EC"/>
+		<stop  offset="0.38" style="stop-color:#6147E9"/>
+		<stop  offset="0.61" style="stop-color:#622FE4"/>
+		<stop  offset="0.62" style="stop-color:#632DE4"/>
+	</linearGradient>
+	
+		<path id="形状_00000015330086763774551180000000156664298259914401_" style="fill:url(#形状_00000075134058584377680020000000290633275844112275_);" d="
+		M867.9,562.4l-87-152.1l-10.3-17.9l46.1-80.5c1.5-2.8,2.4-5.9,2.4-8.9s-0.8-6.1-2.4-8.9l-51.1-89.5c-1.5-2.8-3.8-5-6.5-6.5
+		c-2.7-1.5-5.7-2.4-8.9-2.4H558.7l-45.6-55.2c-3.1-5.4-15.1-19.1-15.1-19.1h-98.4c-3.3,0-6.4,0.9-9.2,2.5c-2.8,1.6-5.1,4-6.7,6.8
+		l-90.3,158L282.8,307h-88.3c-3.2,0-6.2,0.9-8.9,2.4c-2.7,1.5-4.9,3.8-6.5,6.5l-51.1,89.5c-1.5,2.8-2.4,5.9-2.4,8.9s0.8,6.1,2.4,8.9
+		l97.2,170l-46.1,80.5c-1.5,2.8-2.4,5.9-2.4,8.9c0,3.1,0.8,6.1,2.4,8.9l51.1,89.5c1.5,2.8,3.8,5,6.5,6.5c2.7,1.5,5.7,2.4,8.9,2.4
+		h191.6l45.6,75.8c3.1,5.4,15.1-1.4,15.1-1.4h98.4c3.3,0,6.4-0.9,9.2-2.5c2.8-1.6,5.1-4,6.7-6.8l100.9-176.5h88.3
+		c3.2,0,6.2-0.9,8.9-2.4c2.7-1.5,4.9-3.8,6.5-6.5l51.1-89.5c1.6-2.8,2.4-5.9,2.4-8.9C870.3,568.3,869.6,565.2,867.9,562.4z
+		 M396.7,149.2l50.6,88.5l-50.6,106.5h404.8L751,418.5H356.3l-55.7-101.2L396.7,149.2z M437.5,753H244.9l50.6-74.3h106.2L189.1,307
+		h105.4l51,89.2l147.8,258.6l-56,98.1L437.5,753z M750.9,604.4l-50.6-101.2l-202.4,354l-50.6-88.5l50.6-88.5l146.7-261.6h111.3
+		L852,604.4H750.7H750.9z"/>
+	
+		<linearGradient id="形状_00000067932632932638679750000000322923165562110113_" gradientUnits="userSpaceOnUse" x1="-5.4163" y1="1028.4689" x2="31.8163" y2="1028.4689" gradientTransform="matrix(20 0 0 -20 234 21064)">
+		<stop  offset="0" style="stop-color:#615CED"/>
+		<stop  offset="4.000000e-02" style="stop-color:#615CED;stop-opacity:0.96"/>
+		<stop  offset="9.000000e-02" style="stop-color:#615CED;stop-opacity:0.86"/>
+		<stop  offset="0.17" style="stop-color:#615CED;stop-opacity:0.69"/>
+		<stop  offset="0.25" style="stop-color:#615CED;stop-opacity:0.46"/>
+		<stop  offset="0.35" style="stop-color:#615CED;stop-opacity:0.16"/>
+		<stop  offset="0.4" style="stop-color:#615CED;stop-opacity:0"/>
+	</linearGradient>
+	
+		<path id="形状_00000153701526855006986570000002111802051037381022_" style="fill:url(#形状_00000067932632932638679750000000322923165562110113_);" d="
+		M867.9,562.4l-87-152.1l-10.3-17.9l46.1-80.5c1.5-2.8,2.4-5.9,2.4-8.9s-0.8-6.1-2.4-8.9l-51.1-89.5c-1.5-2.8-3.8-5-6.5-6.5
+		c-2.7-1.5-5.7-2.4-8.9-2.4H558.7l-45.6-55.2c-3.1-5.4-15.1-19.1-15.1-19.1h-98.4c-3.3,0-6.4,0.9-9.2,2.5c-2.8,1.6-5.1,4-6.7,6.8
+		l-90.3,158L282.8,307h-88.3c-3.2,0-6.2,0.9-8.9,2.4c-2.7,1.5-4.9,3.8-6.5,6.5l-51.1,89.5c-1.5,2.8-2.4,5.9-2.4,8.9s0.8,6.1,2.4,8.9
+		l97.2,170l-46.1,80.5c-1.5,2.8-2.4,5.9-2.4,8.9c0,3.1,0.8,6.1,2.4,8.9l51.1,89.5c1.5,2.8,3.8,5,6.5,6.5c2.7,1.5,5.7,2.4,8.9,2.4
+		h191.6l45.6,75.8c3.1,5.4,15.1-1.4,15.1-1.4h98.4c3.3,0,6.4-0.9,9.2-2.5c2.8-1.6,5.1-4,6.7-6.8l100.9-176.5h88.3
+		c3.2,0,6.2-0.9,8.9-2.4c2.7-1.5,4.9-3.8,6.5-6.5l51.1-89.5c1.6-2.8,2.4-5.9,2.4-8.9C870.3,568.3,869.6,565.2,867.9,562.4z
+		 M396.7,149.2l50.6,88.5l-50.6,106.5h404.8L751,418.5H356.3l-55.7-101.2L396.7,149.2z M437.5,753H244.9l50.6-74.3h106.2L189.1,307
+		h105.4l51,89.2l147.8,258.6l-56,98.1L437.5,753z M750.9,604.4l-50.6-101.2l-202.4,354l-50.6-88.5l50.6-88.5l146.7-261.6h111.3
+		L852,604.4H750.7H750.9z"/>
+	
+		<linearGradient id="形状_00000014624179049576217780000005287183309742849203_" gradientUnits="userSpaceOnUse" x1="22.7899" y1="1045.6652" x2="3.6059" y2="1011.441" gradientTransform="matrix(20 0 0 -20 234 21064)">
+		<stop  offset="0" style="stop-color:#A7A5F6"/>
+		<stop  offset="5.000000e-02" style="stop-color:#9895F4;stop-opacity:0.79"/>
+		<stop  offset="0.12" style="stop-color:#8784F1;stop-opacity:0.55"/>
+		<stop  offset="0.19" style="stop-color:#7975F0;stop-opacity:0.35"/>
+		<stop  offset="0.25" style="stop-color:#6F6AEE;stop-opacity:0.2"/>
+		<stop  offset="0.31" style="stop-color:#6762ED;stop-opacity:9.000000e-02"/>
+		<stop  offset="0.36" style="stop-color:#625DED;stop-opacity:2.000000e-02"/>
+		<stop  offset="0.4" style="stop-color:#615CED;stop-opacity:0"/>
+	</linearGradient>
+	
+		<path id="形状_00000107577251033893729710000008774002231294313656_" style="fill:url(#形状_00000014624179049576217780000005287183309742849203_);" d="
+		M867.9,562.4l-87-152.1l-10.3-17.9l46.1-80.5c1.5-2.8,2.4-5.9,2.4-8.9s-0.8-6.1-2.4-8.9l-51.1-89.5c-1.5-2.8-3.8-5-6.5-6.5
+		c-2.7-1.5-5.7-2.4-8.9-2.4H558.7l-45.6-55.2c-3.1-5.4-15.1-19.1-15.1-19.1h-98.4c-3.3,0-6.4,0.9-9.2,2.5c-2.8,1.6-5.1,4-6.7,6.8
+		l-90.3,158L282.8,307h-88.3c-3.2,0-6.2,0.9-8.9,2.4c-2.7,1.5-4.9,3.8-6.5,6.5l-51.1,89.5c-1.5,2.8-2.4,5.9-2.4,8.9s0.8,6.1,2.4,8.9
+		l97.2,170l-46.1,80.5c-1.5,2.8-2.4,5.9-2.4,8.9c0,3.1,0.8,6.1,2.4,8.9l51.1,89.5c1.5,2.8,3.8,5,6.5,6.5c2.7,1.5,5.7,2.4,8.9,2.4
+		h191.6l45.6,75.8c3.1,5.4,15.1-1.4,15.1-1.4h98.4c3.3,0,6.4-0.9,9.2-2.5c2.8-1.6,5.1-4,6.7-6.8l100.9-176.5h88.3
+		c3.2,0,6.2-0.9,8.9-2.4c2.7-1.5,4.9-3.8,6.5-6.5l51.1-89.5c1.6-2.8,2.4-5.9,2.4-8.9C870.3,568.3,869.6,565.2,867.9,562.4z
+		 M396.7,149.2l50.6,88.5l-50.6,106.5h404.8L751,418.5H356.3l-55.7-101.2L396.7,149.2z M437.5,753H244.9l50.6-74.3h106.2L189.1,307
+		h105.4l51,89.2l147.8,258.6l-56,98.1L437.5,753z M750.9,604.4l-50.6-101.2l-202.4,354l-50.6-88.5l50.6-88.5l146.7-261.6h111.3
+		L852,604.4H750.7H750.9z"/>
+</g>
+</svg>

--- a/server/tools/generate_image_by_qwen_image_edit_plus.py
+++ b/server/tools/generate_image_by_qwen_image_edit_plus.py
@@ -1,0 +1,48 @@
+from typing import Annotated
+from pydantic import BaseModel, Field
+from langchain_core.tools import tool, InjectedToolCallId  # type: ignore
+from langchain_core.runnables import RunnableConfig
+from tools.utils.image_generation_core import generate_image_with_provider
+
+
+class GenerateImageByQwenImageEditPlusInputSchema(BaseModel):
+    prompt: str = Field(
+        description="Required. The prompt for image generation. If you want to edit an image, please describe what you want to edit in the prompt."
+    )
+    image_size: str = Field(
+        description="Required. Aspect ratio of the image, only these values are allowed: 1:1, 16:9, 4:3, 3:4, 9:16. Choose the best fitting aspect ratio according to the prompt. Best ratio for posters is 3:4"
+    )
+    image_urls: list[str] | None = Field(
+        default=None,
+        description="Optional; One or multiple images to use as reference. Pass a list of image_id here, e.g. ['im_jurheut7.png', 'im_hfuiut78.png']. Best for image editing cases like: Editing specific parts of the image, Removing specific objects, Maintaining visual elements across scenes (character/object consistency), Generating new content in the style of the reference (style transfer), etc."
+    )
+    tool_call_id: Annotated[str, InjectedToolCallId]
+
+
+@tool("generate_image_by_qwen_image_edit_plus",
+      description="Generate an image by qwen image edit plus model using text prompt or optionally pass images for reference or for editing. Use this model if you need to use multiple input images as reference. Supports multiple providers with automatic fallback.",
+      args_schema=GenerateImageByQwenImageEditPlusInputSchema)
+async def generate_image_by_qwen_image_edit_plus(
+    prompt: str,
+    aspect_ratio: str,
+    config: RunnableConfig,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    input_images: list[str] | None = None,
+) -> str:
+    ctx = config.get('configurable', {})
+    canvas_id = ctx.get('canvas_id', '')
+    session_id = ctx.get('session_id', '')
+    print(f"prompt: {prompt} , aspect_ratio: {aspect_ratio} , input_images: {input_images}")
+    return await generate_image_with_provider(
+        canvas_id=canvas_id,
+        session_id=session_id,
+        provider='qwen',
+        model='qwen-image-edit-plus',
+        prompt=prompt,
+        aspect_ratio=aspect_ratio,
+        input_images=input_images,
+    )
+
+
+# Export the tool for easy import
+__all__ = ["generate_image_by_qwen_image_edit_plus"]


### PR DESCRIPTION
- 在constants.ts中新增qwen提供者的名称和图标。
- 在config_service.py中添加qwen的配置，包括API密钥和模型信息。
- 在tool_service.py中注册qwen图像编辑工具。
- 在tuzi_llm_service.py中更新图像编辑逻辑，支持qwen模型。
- 新增qwen.svg图标文件。
- 创建generate_image_by_qwen_image_edit_plus.py工具，支持通过qwen进行图像生成与编辑。